### PR TITLE
Update calc_tmetric_avg3d_monthly_combine_batch.csh

### DIFF
--- a/EQUATES/POST/calc_tmetric_avg3d_monthly_combine_batch.csh
+++ b/EQUATES/POST/calc_tmetric_avg3d_monthly_combine_batch.csh
@@ -11,17 +11,6 @@ set BINDIR = $WORKDIR/POST/calc_tmetric/scripts/BLD_calc_tmetric_v533_gcc
 
 set EXEC = calc_tmetric_v533.exe
 
-set TODAYG = ${START_DATE_H}
-set YYYYMMDD = `date -ud "${TODAYG}" +%Y%m%d` #> Convert YYYY-MM-DD to YYYYMMDD
-set YYYY = `date -ud "${TODAYG}" +%Y`
-set YY = `date -ud "${TODAYG}" +%y`
-set MM = `date -ud "${TODAYG}" +%m`
-set DD = `date -ud "${TODAYG}" +%d`
-
-set tomorrow_date = `date -ud "${TODAYG}+1days" +%Y-%m-%d`
-set MMtomorrow = `date -ud "${tomorrow_date}" +%m`
-
-
 setenv OPERATION AVG
 
 setenv SPECIES_1 ALL
@@ -36,11 +25,5 @@ setenv M3_FILE_6
 setenv OUTFILE ${OUTFILE}
 
 ${BINDIR}/${EXEC}
-
-
-if ( ${MMtomorrow} != ${MM} ) then
-#  aput -q -retention=maximum -a ${ASMDIR_COMBINE2} ${OUTFILE}
-endif
-
 
  exit() 


### PR DESCRIPTION
Removing set commands for date variables that are not used as well as the aput section.